### PR TITLE
Add optional parameters to the ServiceCollection extensions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>1.1.1</VersionPrefix>
+        <VersionPrefix>1.1.2</VersionPrefix>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
 
         <!-- Other useful metadata -->

--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ Or bind from configuration:
 services.AddDynamoDbDistributedLock(configuration);
 ```
 
+If you need to customize the `IAmazonDynamoDB` client, you can pass in AWSOptions, or the configuration section name:
+
+```csharp
+services.AddDynamoDbDistributedLock(configuration, awsOptionsSectionName: "DynamoDb");
+// or configure AWSOptions manually
+var awsOptions = configuration.GetAWSOptions("DynamoDb");
+awsOptions.DefaultClientConfig.ServiceURL = "http://localhost:4566"; // use localstack for testing
+services.AddDynamoDbDistributedLock(options =>
+{
+    options.TableName = "my-lock-table";
+    options.LockTimeoutSeconds = 30;
+    options.PartitionKeyAttribute = "pk";
+    options.SortKeyAttribute = "sk";
+}, awsOptions);
+```
+
 ### appsettings.json
 ```json
 {

--- a/src/DynamoDb.DistributedLock/DynamoDbLockOptions.cs
+++ b/src/DynamoDb.DistributedLock/DynamoDbLockOptions.cs
@@ -7,7 +7,11 @@ namespace DynamoDb.DistributedLock;
 /// </summary>
 public sealed class DynamoDbLockOptions
 {
+    /// <summary>
+    /// The default name of the configuration section for DynamoDB lock settings.
+    /// </summary>
     public const string DynamoDbLockSettings = "DynamoDbLock";
+    
     /// <summary>
     /// The name of the DynamoDB table to use.
     /// </summary>

--- a/test/DynamoDb.DistributedLock.Tests/Retry/ExponentialBackoffRetryPolicyTests.cs
+++ b/test/DynamoDb.DistributedLock.Tests/Retry/ExponentialBackoffRetryPolicyTests.cs
@@ -50,13 +50,11 @@ public class ExponentialBackoffRetryPolicyTests
         var sut = new ExponentialBackoffRetryPolicy(options);
         var operationCalled = 0;
 
-        var result = await sut.ExecuteAsync(
-            _ =>
+        var result = await sut.ExecuteAsync(_ =>
             {
                 operationCalled++;
                 return Task.FromResult(expectedResult);
-            },
-            _ => true);
+            }, _ => true, TestContext.Current.CancellationToken);
 
         result.Should().Be(expectedResult);
         operationCalled.Should().Be(1);
@@ -120,15 +118,13 @@ public class ExponentialBackoffRetryPolicyTests
         var sut = new ExponentialBackoffRetryPolicy(options);
         var operationCalled = 0;
 
-        var result = await sut.ExecuteAsync(
-            _ =>
+        var result = await sut.ExecuteAsync(_ =>
             {
                 operationCalled++;
                 if (operationCalled < 3)
                     throw new InvalidOperationException("Retry me");
                 return Task.FromResult(expectedResult);
-            },
-            _ => true);
+            }, _ => true, TestContext.Current.CancellationToken);
 
         result.Should().Be(expectedResult);
         operationCalled.Should().Be(3);

--- a/test/DynamoDb.DistributedLock.Tests/Retry/RetryIntegrationTests.cs
+++ b/test/DynamoDb.DistributedLock.Tests/Retry/RetryIntegrationTests.cs
@@ -31,7 +31,7 @@ public class RetryIntegrationTests
         var sut = new DynamoDbDistributedLock(dynamo, options);
 
         // Act
-        var result = await sut.AcquireLockAsync(resourceId, ownerId);
+        var result = await sut.AcquireLockAsync(resourceId, ownerId, TestContext.Current.CancellationToken);
 
         // Assert
         result.Should().BeFalse();
@@ -64,7 +64,7 @@ public class RetryIntegrationTests
         var sut = new DynamoDbDistributedLock(dynamo, options);
 
         // Act
-        var result = await sut.AcquireLockAsync(resourceId, ownerId);
+        var result = await sut.AcquireLockAsync(resourceId, ownerId, TestContext.Current.CancellationToken);
 
         // Assert
         result.Should().BeTrue();
@@ -90,7 +90,7 @@ public class RetryIntegrationTests
         var sut = new DynamoDbDistributedLock(dynamo, options);
 
         // Act
-        var result = await sut.AcquireLockAsync(resourceId, ownerId);
+        var result = await sut.AcquireLockAsync(resourceId, ownerId, TestContext.Current.CancellationToken);
 
         // Assert
         result.Should().BeFalse();
@@ -123,7 +123,7 @@ public class RetryIntegrationTests
         var sut = new DynamoDbDistributedLock(dynamo, options);
 
         // Act
-        var result = await sut.AcquireLockAsync(resourceId, ownerId);
+        var result = await sut.AcquireLockAsync(resourceId, ownerId, TestContext.Current.CancellationToken);
 
         // Assert
         result.Should().BeTrue();
@@ -180,7 +180,7 @@ public class RetryIntegrationTests
         var sut = new DynamoDbDistributedLock(dynamo, options);
 
         // Act
-        var result = await sut.AcquireLockHandleAsync(resourceId, ownerId);
+        var result = await sut.AcquireLockHandleAsync(resourceId, ownerId, TestContext.Current.CancellationToken);
 
         // Assert
         result.Should().NotBeNull();
@@ -209,7 +209,7 @@ public class RetryIntegrationTests
         var sut = new DynamoDbDistributedLock(dynamo, options);
 
         // Act
-        var result = await sut.AcquireLockAsync(resourceId, ownerId);
+        var result = await sut.AcquireLockAsync(resourceId, ownerId, TestContext.Current.CancellationToken);
 
         // Assert
         result.Should().BeFalse();


### PR DESCRIPTION
* Add optional parameters to the ServiceCollection extensions to configure dynamodb client. Fix warnings in unit tests by passing test cancellation token
* add tests

# 🚀 Pull Request

## 📋 Summary

This allows users to configure the DynamoDB client in more ways. This can be helpful in scenarios such as needing to set a custom ServiceURL for private link inside aws, or to use localstack for testing.

---

## ✅ Checklist

- [x] My changes build cleanly
- [x] I’ve added/updated relevant tests
- [x] I’ve added/updated documentation or README
- [x] I’ve followed the coding style for this project
- [x] I’ve tested the changes locally (if applicable)

---

## 🧪 Related Issues or PRs

Closes #25 

---

## 💬 Notes for Reviewers

This contains a binary breaking change due to the optional parameters.

I went ahead and fixed some xunit analyzer warnings about cancellation tokens in the tests. It was so close to no warnings in the build I couldn't resist 🙂
